### PR TITLE
Fix hex_to_rgb extracting a hex from non hex strings

### DIFF
--- a/src/converters/hex_to_rgb.rs
+++ b/src/converters/hex_to_rgb.rs
@@ -24,6 +24,8 @@ pub(crate) fn from_hex(s: &[u8]) -> Result<[u32; 3], ()> {
     if bl.is_ascii_hexdigit() {
       buff[buff_len] = bl;
       buff_len += 1;
+    } else {
+      return Err(());
     }
   }
 
@@ -71,6 +73,7 @@ mod test {
       "тест",
       "ffccfg",
       "",
+      "Magenta"
     ];
 
     for (s, t) in valid.iter() {


### PR DESCRIPTION
If a string had 3 or 6 valid ascii hex characters and one of those characters was the last character in the string the 'from_hex' function would return a valid hex. Returning an error if any invalid ascii hex is encountered in the string fixes this.

For example in the string 'Magenta' the hex extracted would be 'aea'.
Another one is 'DarkGray' being extracted as 'daa'.