### PR TITLE
Added serde derives and formatted code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,14 @@ license = "MIT"
 homepage = "https://github.com/emgyrz/colorsys.rs"
 repository = "https://github.com/emgyrz/colorsys.rs.git"
 keywords = ["colors", "converter", "rgb", "hsl", "cmyk"]
-categories = [ "graphics"]
+categories = ["graphics"]
 edition = "2024"
 readme = "README.md"
 
 [dependencies]
-
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [features]
-default = [ "std" ]
+default = ["std"]
 std = []
+serde = ["dep:serde", "std"]

--- a/src/ansi/mod.rs
+++ b/src/ansi/mod.rs
@@ -24,6 +24,7 @@ use crate::Rgb;
 ///
 /// ```
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Ansi256(pub(crate) u8);
 
 impl Ansi256 {
@@ -67,7 +68,13 @@ impl From<Ansi256> for Rgb {
     if code < 16 {
       let mut base = code;
       let mut mul = 128;
-      if code == 7 { mul = 192; } else if code == 8 { base = 7; } else if code > 8 { mul = 255; }
+      if code == 7 {
+        mul = 192;
+      } else if code == 8 {
+        base = 7;
+      } else if code > 8 {
+        mul = 255;
+      }
       let r = (base & 1) * mul;
       let g = ((base & 2) >> 1) * mul;
       let b = ((base & 4) >> 2) * mul;
@@ -93,8 +100,8 @@ impl From<Ansi256> for Rgb {
 
 #[cfg(test)]
 mod test {
-  use crate::ansi::Ansi256;
   use crate::Rgb;
+  use crate::ansi::Ansi256;
 
   #[test]
   fn rgb_to_ansi_test() {
@@ -130,4 +137,3 @@ mod test {
     }
   }
 }
-

--- a/src/cmyk/from.rs
+++ b/src/cmyk/from.rs
@@ -1,6 +1,6 @@
-use crate::{Cmyk, Rgb};
 use crate::cmyk::CmykRatio;
 use crate::converters::{cmyk_to_rgb, rgb_to_cmyk};
+use crate::{Cmyk, Rgb};
 
 fn cmyk_from_ratio(r: &CmykRatio) -> Cmyk {
   let mut u = r.units.clone();
@@ -91,18 +91,26 @@ impl From<Cmyk> for Rgb {
 
 
 impl From<[f64; 4]> for Cmyk {
-  fn from(a: [f64; 4]) -> Self { Cmyk::new(a[0], a[1], a[2], a[3], None) }
+  fn from(a: [f64; 4]) -> Self {
+    Cmyk::new(a[0], a[1], a[2], a[3], None)
+  }
 }
 
 impl From<&[f64; 4]> for Cmyk {
-  fn from(a: &[f64; 4]) -> Self { Cmyk::new(a[0], a[1], a[2], a[3], None) }
+  fn from(a: &[f64; 4]) -> Self {
+    Cmyk::new(a[0], a[1], a[2], a[3], None)
+  }
 }
 
 
 impl Into<[f64; 4]> for Cmyk {
-  fn into(self: Cmyk) -> [f64; 4] { self.units.into() }
+  fn into(self: Cmyk) -> [f64; 4] {
+    self.units.into()
+  }
 }
 
 impl Into<[f64; 4]> for &Cmyk {
-  fn into(self) -> [f64; 4] { self.units.clone().into() }
+  fn into(self) -> [f64; 4] {
+    self.units.clone().into()
+  }
 }

--- a/src/cmyk/mod.rs
+++ b/src/cmyk/mod.rs
@@ -2,12 +2,12 @@ use core::ops::{Add, AddAssign, Sub, SubAssign};
 
 pub use ratio::CmykRatio;
 
-use crate::consts::PERCENT_MAX;
 use crate::Rgb;
+use crate::consts::PERCENT_MAX;
 use crate::units::{Alpha, GetColorUnits, Unit, Units};
 
-mod ratio;
 mod from;
+mod ratio;
 
 
 /// The CMYK color model.
@@ -33,6 +33,7 @@ mod from;
 ///
 /// ```
 #[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cmyk {
   pub(crate) units: Units,
 }
@@ -53,15 +54,31 @@ impl Cmyk {
     Cmyk::from_units(u)
   }
 
-  pub fn cyan(&self) -> f64 { self.units[0] }
-  pub fn magenta(&self) -> f64 { self.units[1] }
-  pub fn yellow(&self) -> f64 { self.units[2] }
-  pub fn key(&self) -> f64 { self.units[3] }
+  pub fn cyan(&self) -> f64 {
+    self.units[0]
+  }
+  pub fn magenta(&self) -> f64 {
+    self.units[1]
+  }
+  pub fn yellow(&self) -> f64 {
+    self.units[2]
+  }
+  pub fn key(&self) -> f64 {
+    self.units[3]
+  }
 
-  pub fn set_cyan(&mut self, c: f64) { self.units.list[0].set(c); }
-  pub fn set_magenta(&mut self, m: f64) { self.units.list[1].set(m); }
-  pub fn set_yellow(&mut self, y: f64) { self.units.list[2].set(y); }
-  pub fn set_key(&mut self, k: f64) { self.units.list[3].set(k); }
+  pub fn set_cyan(&mut self, c: f64) {
+    self.units.list[0].set(c);
+  }
+  pub fn set_magenta(&mut self, m: f64) {
+    self.units.list[1].set(m);
+  }
+  pub fn set_yellow(&mut self, y: f64) {
+    self.units.list[2].set(y);
+  }
+  pub fn set_key(&mut self, k: f64) {
+    self.units.list[3].set(k);
+  }
 
   /// Returns same color in RGB color model
   /// # Example
@@ -87,13 +104,19 @@ impl Cmyk {
 
 
 impl GetColorUnits for Cmyk {
-  fn get_units(&self) -> &Units { &self.units }
-  fn get_units_mut(&mut self) -> &mut Units { &mut self.units }
+  fn get_units(&self) -> &Units {
+    &self.units
+  }
+  fn get_units_mut(&mut self) -> &mut Units {
+    &mut self.units
+  }
 }
 
 
 impl AsRef<Cmyk> for Cmyk {
-  fn as_ref(&self) -> &Cmyk { self }
+  fn as_ref(&self) -> &Cmyk {
+    self
+  }
 }
 
 impl Default for Cmyk {
@@ -101,6 +124,3 @@ impl Default for Cmyk {
     Cmyk::from_units(new_cmyk_units(0.0, 0.0, 0.0, PERCENT_MAX))
   }
 }
-
-
-

--- a/src/cmyk/ratio.rs
+++ b/src/cmyk/ratio.rs
@@ -1,6 +1,7 @@
 use crate::units::Units;
 
 #[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CmykRatio {
   pub(crate) units: Units,
 }
@@ -12,15 +13,31 @@ impl CmykRatio {
     CmykRatio::from_units(u)
   }
 
-  pub fn cyan(&self) -> f64 { self.units[0] }
-  pub fn magenta(&self) -> f64 { self.units[1] }
-  pub fn yellow(&self) -> f64 { self.units[2] }
-  pub fn key(&self) -> f64 { self.units[3] }
+  pub fn cyan(&self) -> f64 {
+    self.units[0]
+  }
+  pub fn magenta(&self) -> f64 {
+    self.units[1]
+  }
+  pub fn yellow(&self) -> f64 {
+    self.units[2]
+  }
+  pub fn key(&self) -> f64 {
+    self.units[3]
+  }
 
-  pub fn set_cyan(&mut self, c: f64) { self.units.list[0].set(c); }
-  pub fn set_magenta(&mut self, m: f64) { self.units.list[1].set(m); }
-  pub fn set_yellow(&mut self, y: f64) { self.units.list[2].set(y); }
-  pub fn set_key(&mut self, k: f64) { self.units.list[3].set(k); }
+  pub fn set_cyan(&mut self, c: f64) {
+    self.units.list[0].set(c);
+  }
+  pub fn set_magenta(&mut self, m: f64) {
+    self.units.list[1].set(m);
+  }
+  pub fn set_yellow(&mut self, y: f64) {
+    self.units.list[2].set(y);
+  }
+  pub fn set_key(&mut self, k: f64) {
+    self.units.list[3].set(k);
+  }
 
   pub(crate) fn from_units(u: Units) -> Self {
     CmykRatio { units: u }
@@ -29,7 +46,9 @@ impl CmykRatio {
 
 
 impl AsRef<CmykRatio> for CmykRatio {
-  fn as_ref(&self) -> &CmykRatio { self }
+  fn as_ref(&self) -> &CmykRatio {
+    self
+  }
 }
 
 impl Default for CmykRatio {
@@ -39,25 +58,33 @@ impl Default for CmykRatio {
 }
 
 impl From<[f64; 4]> for CmykRatio {
-  fn from(a: [f64; 4]) -> Self { CmykRatio::new(a[0], a[1], a[2], a[3], 1.0) }
+  fn from(a: [f64; 4]) -> Self {
+    CmykRatio::new(a[0], a[1], a[2], a[3], 1.0)
+  }
 }
 
 impl From<&[f64; 4]> for CmykRatio {
-  fn from(a: &[f64; 4]) -> Self { CmykRatio::new(a[0], a[1], a[2], a[3], 1.0) }
+  fn from(a: &[f64; 4]) -> Self {
+    CmykRatio::new(a[0], a[1], a[2], a[3], 1.0)
+  }
 }
 
 impl Into<[f64; 4]> for CmykRatio {
-  fn into(self: CmykRatio) -> [f64; 4] { self.units.into() }
+  fn into(self: CmykRatio) -> [f64; 4] {
+    self.units.into()
+  }
 }
 
 impl Into<[f64; 4]> for &CmykRatio {
-  fn into(self) -> [f64; 4] { self.units.clone().into() }
+  fn into(self) -> [f64; 4] {
+    self.units.clone().into()
+  }
 }
 
 #[cfg(test)]
 mod test {
-  use crate::{Cmyk, Rgb};
   use crate::converters::cmyk_to_rgb;
+  use crate::{Cmyk, Rgb};
 
   #[test]
   fn cmyk_to_rbg_test() {

--- a/src/common/alpha.rs
+++ b/src/common/alpha.rs
@@ -30,8 +30,13 @@ pub trait ColorAlpha {
 }
 
 
-impl<T> ColorAlpha for T where T: GetColorUnits {
-  fn alpha(&self) -> f64 { self.get_units().alpha.get_f64() }
+impl<T> ColorAlpha for T
+where
+  T: GetColorUnits,
+{
+  fn alpha(&self) -> f64 {
+    self.get_units().alpha.get_f64()
+  }
   fn get_alpha(&self) -> f64 {
     self.alpha()
   }

--- a/src/common/approx.rs
+++ b/src/common/approx.rs
@@ -15,7 +15,10 @@ pub fn approx(x: f64, y: f64, precision: f64) -> bool {
   f64_abs(x - y) < precision
 }
 
-impl<T> ApproxEq<T> for T where T: GetColorUnits {
+impl<T> ApproxEq<T> for T
+where
+  T: GetColorUnits,
+{
   fn approx_eq(&self, other: &T) -> bool {
     self.get_units().approx_eq(other.get_units())
   }

--- a/src/common/hsv_hsl_from_str.rs
+++ b/src/common/hsv_hsl_from_str.rs
@@ -4,8 +4,8 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use super::Hs;
-use crate::err::{make_parse_err, ParseError};
-use crate::{consts, ColorTuple};
+use crate::err::{ParseError, make_parse_err};
+use crate::{ColorTuple, consts};
 
 use consts::{ALL_MIN, HUE_MAX, PERCENT_MAX, RATIO_MAX};
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -10,6 +10,7 @@ mod tuple_to_string;
 
 pub mod approx;
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Hs {
   #[allow(dead_code)]
   Hsv,
@@ -24,11 +25,7 @@ pub(crate) fn f64_abs(n: f64) -> f64 {
 
 #[cfg(not(feature = "std"))]
 pub(crate) fn f64_abs(n: f64) -> f64 {
-  if n < 0.0 {
-    -n
-  } else {
-    n
-  }
+  if n < 0.0 { -n } else { n }
 }
 
 #[cfg(feature = "std")]
@@ -43,11 +40,7 @@ pub(crate) fn f64_round(n: f64) -> f64 {
   if f.is_nan() || f == 0.0 {
     n
   } else if n > 0.0 {
-    if f < 0.5 {
-      n - f
-    } else {
-      n - f + 1.0
-    }
+    if f < 0.5 { n - f } else { n - f + 1.0 }
   } else if -f < 0.5 {
     n - f
   } else {

--- a/src/common/tuple_to_string.rs
+++ b/src/common/tuple_to_string.rs
@@ -1,7 +1,7 @@
+use crate::common::{f64_abs, f64_round};
+use crate::{ColorTupleA, normalize::round_ratio};
 #[cfg(not(feature = "std"))]
 use alloc::string::String;
-use crate::{normalize::round_ratio, ColorTupleA};
-use crate::common::{f64_abs, f64_round};
 
 pub fn tuple_to_string(tuple: &ColorTupleA, prefix: &str) -> String {
   use core::fmt::Write;
@@ -16,18 +16,15 @@ pub fn tuple_to_string(tuple: &ColorTupleA, prefix: &str) -> String {
 
   let is_hsl = prefix == "hsl";
   let mut result = String::new();
-  [x, y, z]
-    .iter()
-    .enumerate()
-    .for_each(|(ind, u)| {
-      let _ = write!(result, "{}", f64_round(**u));
-      if is_hsl && (ind == 1 || ind == 2) {
-        result.push('%');
-      }
-      if ind != 2 {
-        result.push(',');
-      }
-    });
+  [x, y, z].iter().enumerate().for_each(|(ind, u)| {
+    let _ = write!(result, "{}", f64_round(**u));
+    if is_hsl && (ind == 1 || ind == 2) {
+      result.push('%');
+    }
+    if ind != 2 {
+      result.push(',');
+    }
+  });
 
   if a != "1" {
     start.push('a');
@@ -37,4 +34,3 @@ pub fn tuple_to_string(tuple: &ColorTupleA, prefix: &str) -> String {
 
   format!("{}({})", start, result)
 }
-

--- a/src/converters/hex_to_rgb.rs
+++ b/src/converters/hex_to_rgb.rs
@@ -1,4 +1,4 @@
-use err::{make_parse_err, ParseError};
+use err::{ParseError, make_parse_err};
 
 use crate::err;
 
@@ -20,7 +20,9 @@ pub(crate) fn from_hex(s: &[u8]) -> Result<[u32; 3], ()> {
     }
 
     let bl = b.to_ascii_lowercase();
-    if bl == HASH { continue; }
+    if bl == HASH {
+      continue;
+    }
     if bl.is_ascii_hexdigit() {
       buff[buff_len] = bl;
       buff_len += 1;
@@ -50,7 +52,7 @@ fn hex_digit_to_rgb(num: u32) -> [u32; 3] {
 
 #[cfg(test)]
 mod test {
-  use crate::converters::hex_to_rgb::{from_hex};
+  use crate::converters::hex_to_rgb::from_hex;
 
   #[test]
   fn from_hex_test() {
@@ -63,18 +65,11 @@ mod test {
       ("#ffFfff", [255; 3]),
       ("#ffffff", [255; 3]),
       ("#777", [119; 3]),
-      ("F7b3aA", [247, 179, 170])
+      ("F7b3aA", [247, 179, 170]),
     ];
 
-    let invalid = [
-      "0000",
-      "#0000f221",
-      "#000000a",
-      "тест",
-      "ffccfg",
-      "",
-      "Magenta"
-    ];
+    let invalid =
+      ["0000", "#0000f221", "#000000a", "тест", "ffccfg", "", "Magenta"];
 
     for (s, t) in valid.iter() {
       let rgb = from_hex(s.as_bytes()).unwrap();
@@ -87,5 +82,3 @@ mod test {
     }
   }
 }
-
-

--- a/src/converters/hsl_to_rgb.rs
+++ b/src/converters/hsl_to_rgb.rs
@@ -1,5 +1,5 @@
-use crate::consts::RGB_UNIT_MAX;
 use crate::Hsl;
+use crate::consts::RGB_UNIT_MAX;
 use crate::normalize::bound_ratio;
 use crate::rgb::new_rgb_units;
 use crate::units::Units;

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -1,11 +1,11 @@
 mod hex_to_rgb;
 mod hsl_to_rgb;
+mod rgb_cmyk;
 mod rgb_to_hex;
 mod rgb_to_hsl;
-mod rgb_cmyk;
 
 pub(crate) use hex_to_rgb::hex_to_rgb;
 pub(crate) use hsl_to_rgb::hsl_to_rgb;
+pub(crate) use rgb_cmyk::{cmyk_to_rgb, rgb_to_cmyk};
 pub(crate) use rgb_to_hex::rgb_to_hex;
 pub(crate) use rgb_to_hsl::rgb_to_hsl;
-pub(crate) use rgb_cmyk::{rgb_to_cmyk, cmyk_to_rgb};

--- a/src/converters/rgb_cmyk.rs
+++ b/src/converters/rgb_cmyk.rs
@@ -1,10 +1,10 @@
-use crate::{Cmyk, Rgb};
 use crate::cmyk::CmykRatio;
 use crate::consts::{RATIO_MAX, RGB_UNIT_MAX};
+use crate::{Cmyk, Rgb};
 
 pub(crate) fn rgb_to_cmyk(rgb: &Rgb) -> Cmyk {
   let rgb_r = rgb.units.as_ratio();
-  let [ r, g, b ]: [f64; 3] = (&rgb_r).into();
+  let [r, g, b]: [f64; 3] = (&rgb_r).into();
   let k = RATIO_MAX - rgb_r.max().0;
   let x = RATIO_MAX - k;
 
@@ -16,7 +16,7 @@ pub(crate) fn rgb_to_cmyk(rgb: &Rgb) -> Cmyk {
 }
 
 pub(crate) fn cmyk_to_rgb(cmyk: &Cmyk) -> Rgb {
-  let [ c, m, y, k ]: [f64; 4] = cmyk.units.as_ratio().into();
+  let [c, m, y, k]: [f64; 4] = cmyk.units.as_ratio().into();
   let x = RGB_UNIT_MAX * (1.0 - k);
 
   Rgb::new((1.0 - c) * x, (1.0 - m) * x, (1.0 - y) * x, cmyk.units.alpha.get())
@@ -25,8 +25,8 @@ pub(crate) fn cmyk_to_rgb(cmyk: &Cmyk) -> Rgb {
 #[allow(clippy::float_cmp)]
 #[cfg(test)]
 mod test {
-  use crate::{Cmyk, Rgb};
   use crate::converters::{cmyk_to_rgb, rgb_to_cmyk};
+  use crate::{Cmyk, Rgb};
 
   #[test]
   fn cmyk_to_rbg_test() {

--- a/src/converters/rgb_to_hex.rs
+++ b/src/converters/rgb_to_hex.rs
@@ -6,11 +6,7 @@ use crate::common::f64_round;
 
 fn to_hex(n: f64) -> String {
   let s = format!("{:x}", f64_round(n) as u32);
-  if s.len() == 1 {
-    String::from("0") + &s
-  } else {
-    s
-  }
+  if s.len() == 1 { String::from("0") + &s } else { s }
 }
 
 pub fn rgb_to_hex(t: &ColorTuple) -> String {

--- a/src/converters/rgb_to_hsl.rs
+++ b/src/converters/rgb_to_hsl.rs
@@ -34,7 +34,9 @@ pub fn rgb_to_hsl(rgb: &Rgb) -> Units {
     1 => (blue - red) / max_min_delta + 2.0,
     // blue
     2 => (red - green) / max_min_delta + 4.0,
-    _ => { unreachable!() }
+    _ => {
+      unreachable!()
+    }
   };
 
   new_hsl_units(hue * 60.0, saturation * PERCENT_MAX, luminance * PERCENT_MAX)
@@ -42,7 +44,7 @@ pub fn rgb_to_hsl(rgb: &Rgb) -> Units {
 
 #[test]
 fn rgb_to_hsl_tst() {
-  use crate::{ColorTuple, Rgb, ApproxEq};
+  use crate::{ApproxEq, ColorTuple, Rgb};
   fn a(x: ColorTuple, y: ColorTuple) -> bool {
     let from_rgb_u = rgb_to_hsl(&Rgb::from(x));
     let hsl_u = new_hsl_units(y.0, y.1, y.2);

--- a/src/err.rs
+++ b/src/err.rs
@@ -1,8 +1,9 @@
-use core::fmt;
 #[cfg(not(feature = "std"))]
 use alloc::string::String;
+use core::fmt;
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ParseError {
   pub message: String,
 }

--- a/src/hsl/from.rs
+++ b/src/hsl/from.rs
@@ -1,6 +1,4 @@
-use crate::{
-  ColorAlpha, converters::*, ratio_converters::ratio_to_hsla,
-};
+use crate::{ColorAlpha, converters::*, ratio_converters::ratio_to_hsla};
 
 use super::{Hsl, HslRatio, Rgb};
 

--- a/src/hsl/mod.rs
+++ b/src/hsl/mod.rs
@@ -3,9 +3,9 @@ use alloc::string::String;
 
 pub use ratio::HslRatio;
 
-use crate::{ColorAlpha, ColorTupleA, ColorUnitsIter, ParseError, Rgb};
 use crate::common::{Hs, hsl_hsv_from_str, tuple_to_string};
 use crate::units::{Alpha, GetColorUnits, Unit, Units};
+use crate::{ColorAlpha, ColorTupleA, ColorUnitsIter, ParseError, Rgb};
 
 #[cfg(test)]
 mod tests;
@@ -23,13 +23,19 @@ mod transform;
 /// * saturation: 0.0 - 100.0
 /// * alpha: 0.0 - 1.0
 #[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Hsl {
   pub(crate) units: Units,
 }
 
 iter_def!(Hsl);
 pub(crate) fn new_hsl_units(h: f64, s: f64, l: f64) -> Units {
-  let ul = [Unit::new_hue(h), Unit::new_percent(s), Unit::new_percent(l), Unit::default()];
+  let ul = [
+    Unit::new_hue(h),
+    Unit::new_percent(s),
+    Unit::new_percent(l),
+    Unit::default(),
+  ];
   Units { len: 3, list: ul, alpha: Alpha::default() }
 }
 
@@ -42,16 +48,24 @@ impl Hsl {
     Hsl { units }
   }
 
-  pub(crate) fn from_units(u: Units) -> Self { Hsl { units: u } }
+  pub(crate) fn from_units(u: Units) -> Self {
+    Hsl { units: u }
+  }
 
   pub fn to_css_string(&self) -> String {
     let t: ColorTupleA = self.into();
     tuple_to_string(&t, "hsl")
   }
 
-  pub fn hue(&self) -> f64 { self.units[0] }
-  pub fn saturation(&self) -> f64 { self.units[1] }
-  pub fn lightness(&self) -> f64 { self.units[2] }
+  pub fn hue(&self) -> f64 {
+    self.units[0]
+  }
+  pub fn saturation(&self) -> f64 {
+    self.units[1]
+  }
+  pub fn lightness(&self) -> f64 {
+    self.units[2]
+  }
 
   #[deprecated(since = "0.7.0", note = "Please use `hue` instead")]
   pub fn get_hue(&self) -> f64 {
@@ -66,9 +80,15 @@ impl Hsl {
     self.lightness()
   }
 
-  pub fn set_hue(&mut self, val: f64) { self.units.list[0].set(val); }
-  pub fn set_saturation(&mut self, val: f64) { self.units.list[1].set(val); }
-  pub fn set_lightness(&mut self, val: f64) { self.units.list[2].set(val); }
+  pub fn set_hue(&mut self, val: f64) {
+    self.units.list[0].set(val);
+  }
+  pub fn set_saturation(&mut self, val: f64) {
+    self.units.list[1].set(val);
+  }
+  pub fn set_lightness(&mut self, val: f64) {
+    self.units.list[2].set(val);
+  }
 
   /// Returns an iterator over three color units and the possibly alpha value.
   pub fn iter(&self) -> ColorUnitsIter {

--- a/src/hsl/ratio.rs
+++ b/src/hsl/ratio.rs
@@ -1,4 +1,4 @@
-use crate::units::{Units, GetColorUnits};
+use crate::units::{GetColorUnits, Units};
 
 ///
 /// Hsl representation as ratio (from `0.0` to `1.0`).
@@ -23,6 +23,7 @@ use crate::units::{Units, GetColorUnits};
 /// ```
 ///
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HslRatio {
   pub(super) units: Units,
 }
@@ -34,12 +35,22 @@ impl HslRatio {
     HslRatio::from_units(units)
   }
 
-  pub fn h(&self) -> f64 { self.units[0] }
-  pub fn s(&self) -> f64 { self.units[1] }
-  pub fn l(&self) -> f64 { self.units[2] }
-  pub fn a(&self) -> f64 { self.units.alpha.get_f64() }
+  pub fn h(&self) -> f64 {
+    self.units[0]
+  }
+  pub fn s(&self) -> f64 {
+    self.units[1]
+  }
+  pub fn l(&self) -> f64 {
+    self.units[2]
+  }
+  pub fn a(&self) -> f64 {
+    self.units.alpha.get_f64()
+  }
 
-  pub(crate) fn from_units(u: Units) -> Self { HslRatio { units: u } }
+  pub(crate) fn from_units(u: Units) -> Self {
+    HslRatio { units: u }
+  }
 }
 
 impl AsRef<HslRatio> for HslRatio {

--- a/src/hsl/tests.rs
+++ b/src/hsl/tests.rs
@@ -1,5 +1,5 @@
-use crate::{ApproxEq, ColorTuple, Hsl, Rgb};
 use crate::common::f64_round;
+use crate::{ApproxEq, ColorTuple, Hsl, Rgb};
 
 fn round(n: f64) -> u32 {
   f64_round(n) as u32

--- a/src/hsl/transform.rs
+++ b/src/hsl/transform.rs
@@ -1,6 +1,6 @@
-use crate::{ColorTransform, SaturationInSpace};
 use crate::consts::{ALL_MIN, HUE_MAX};
 use crate::normalize::bound_hue;
+use crate::{ColorTransform, SaturationInSpace};
 
 use super::Hsl;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,8 @@ extern crate alloc;
 
 mod macros;
 
+mod ansi;
+mod cmyk;
 mod common;
 mod consts;
 mod converters;
@@ -171,20 +173,18 @@ mod err;
 mod hsl;
 mod normalize;
 mod rgb;
-mod ansi;
-mod cmyk;
 mod units;
 
 pub mod prelude;
 pub mod ratio_converters;
 
+pub use ansi::Ansi256;
+pub use cmyk::{Cmyk, CmykRatio};
 pub use common::approx::{ApproxEq, DEFAULT_APPROX_EQ_PRECISION};
-pub use common::{ColorUnitsIter, ColorAlpha};
+pub use common::{ColorAlpha, ColorUnitsIter};
 pub use err::ParseError;
 pub use hsl::{Hsl, HslRatio};
 pub use rgb::{GrayScaleMethod, Rgb, RgbRatio};
-pub use cmyk::{Cmyk, CmykRatio};
-pub use ansi::{Ansi256};
 
 /// Use to transfer and collect color values.
 /// May be for example `($red,$green,$blue)` or `($hue,$saturation,$value)`
@@ -193,6 +193,7 @@ pub type ColorTuple = (f64, f64, f64);
 /// For example `($hue,$saturation,$lightness,$alpha)`
 pub type ColorTupleA = (f64, f64, f64, f64);
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SaturationInSpace {
   Hsl(f64),
   Hsv(f64),
@@ -221,4 +222,3 @@ pub trait ColorTransform {
   /// Just inverts color
   fn invert(&mut self);
 }
-

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -27,65 +27,78 @@ macro_rules! into_for_some {
 
 macro_rules! ops_def {
   ($name: ident) => {
+    impl<'a> Add for &'a $name {
+      type Output = $name;
+      fn add(self, rhs: &$name) -> $name {
+        $name::from_units(&self.units + &rhs.units)
+      }
+    }
+    impl<'a> Add for &'a mut $name {
+      type Output = $name;
+      fn add(self, rhs: &'a mut $name) -> $name {
+        $name::from_units(&self.units + &rhs.units)
+      }
+    }
+    impl Add for $name {
+      type Output = $name;
+      fn add(self, rhs: Self) -> Self {
+        $name::from_units(&self.units + &rhs.units)
+      }
+    }
+    impl AddAssign for $name {
+      fn add_assign(&mut self, rhs: Self) {
+        *self = $name::from_units(&self.units + &rhs.units);
+      }
+    }
 
-impl<'a> Add for &'a $name {
-  type Output = $name;
-  fn add(self, rhs: &$name) -> $name { $name::from_units(&self.units + &rhs.units) }
-}
-impl<'a> Add for &'a mut $name {
-  type Output = $name;
-  fn add(self, rhs: &'a mut $name) -> $name { $name::from_units(&self.units + &rhs.units) }
-}
-impl Add for $name {
-  type Output = $name;
-  fn add(self, rhs: Self) -> Self { $name::from_units(&self.units + &rhs.units) }
-}
-impl AddAssign for $name {
-  fn add_assign(&mut self, rhs: Self) { *self = $name::from_units(&self.units + &rhs.units); }
-}
 
+    impl Sub for $name {
+      type Output = $name;
+      fn sub(self, rhs: Self) -> Self {
+        $name::from_units(&self.units - &rhs.units)
+      }
+    }
 
-impl Sub for $name {
-  type Output = $name;
-  fn sub(self, rhs: Self) -> Self { $name::from_units(&self.units - &rhs.units) }
-}
+    impl<'a> Sub for &'a $name {
+      type Output = $name;
+      fn sub(self, rhs: Self) -> $name {
+        $name::from_units(&self.units - &rhs.units)
+      }
+    }
 
-impl<'a> Sub for &'a $name {
-  type Output = $name;
-  fn sub(self, rhs: Self) -> $name { $name::from_units(&self.units - &rhs.units) }
-}
+    impl<'a> Sub for &'a mut $name {
+      type Output = $name;
+      fn sub(self, rhs: Self) -> $name {
+        $name::from_units(&self.units - &rhs.units)
+      }
+    }
 
-impl<'a> Sub for &'a mut $name {
-  type Output = $name;
-  fn sub(self, rhs: Self) -> $name { $name::from_units(&self.units - &rhs.units) }
-}
-
-impl SubAssign for $name {
-  fn sub_assign(&mut self, rhs: Self) { *self = $name::from_units(&self.units - &rhs.units); }
-}
-
-};
+    impl SubAssign for $name {
+      fn sub_assign(&mut self, rhs: Self) {
+        *self = $name::from_units(&self.units - &rhs.units);
+      }
+    }
+  };
 }
 
 
 
 macro_rules! iter_def {
   ($name: ident) => {
-impl<'a> core::iter::IntoIterator for &'a $name {
-  type Item = f64;
-  type IntoIter = ColorUnitsIter;
-  fn into_iter(self) -> ColorUnitsIter {
-    self.iter()
-  }
-}
+    impl<'a> core::iter::IntoIterator for &'a $name {
+      type Item = f64;
+      type IntoIter = ColorUnitsIter;
+      fn into_iter(self) -> ColorUnitsIter {
+        self.iter()
+      }
+    }
 
-impl core::iter::IntoIterator for $name {
-  type Item = f64;
-  type IntoIter = ColorUnitsIter;
-  fn into_iter(self) -> ColorUnitsIter {
-    self.iter()
-  }
-}
-
-};
+    impl core::iter::IntoIterator for $name {
+      type Item = f64;
+      type IntoIter = ColorUnitsIter;
+      fn into_iter(self) -> ColorUnitsIter {
+        self.iter()
+      }
+    }
+  };
 }

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -1,5 +1,5 @@
 use super::consts::{ALL_MIN, HUE_MAX, PERCENT_MAX, RATIO_MAX, RGB_UNIT_MAX};
-use crate::common::{f64_round};
+use crate::common::f64_round;
 
 fn normalize(val: f64, max: f64) -> f64 {
   if val < ALL_MIN {

--- a/src/rgb/from.rs
+++ b/src/rgb/from.rs
@@ -1,8 +1,6 @@
-use crate::{
-  ColorAlpha, Hsl, ratio_converters::ratio_to_rgba, Rgb,
-};
 use crate::converters::*;
 use crate::rgb::RgbRatio;
+use crate::{ColorAlpha, Hsl, Rgb, ratio_converters::ratio_to_rgba};
 
 macro_rules! from_for_rgb {
   ($from_type: ty, $val: ident, $conv: block) => {

--- a/src/rgb/from_str.rs
+++ b/src/rgb/from_str.rs
@@ -3,8 +3,8 @@ use alloc::vec::Vec;
 
 use consts::{ALL_MIN, RATIO_MAX, RGB_UNIT_MAX};
 
+use crate::err::{ParseError, make_parse_err};
 use crate::{ColorTuple, consts};
-use crate::err::{make_parse_err, ParseError};
 
 pub fn rgb(s: &str) -> Result<(ColorTuple, Option<f64>), ParseError> {
   let make_err = || Err(make_parse_err(s, "rgb or rgba"));

--- a/src/rgb/grayscale.rs
+++ b/src/rgb/grayscale.rs
@@ -2,6 +2,7 @@ use crate::ColorTuple;
 
 use super::Rgb;
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum GrayScaleMethod {
   Average,
   AverageProminent,

--- a/src/rgb/mod.rs
+++ b/src/rgb/mod.rs
@@ -5,10 +5,12 @@ pub use grayscale::GrayScaleMethod;
 use grayscale::rgb_grayscale;
 pub use ratio::RgbRatio;
 
-use crate::{ColorAlpha, ColorTuple, ColorTupleA, converters, Hsl, ColorUnitsIter};
-use crate::common::{tuple_to_string};
+use crate::common::tuple_to_string;
 use crate::err::ParseError;
 use crate::units::{Alpha, GetColorUnits, Unit, Units};
+use crate::{
+  ColorAlpha, ColorTuple, ColorTupleA, ColorUnitsIter, Hsl, converters,
+};
 
 #[cfg(test)]
 mod tests;
@@ -68,6 +70,7 @@ mod transform;
 /// ```
 ///
 #[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rgb {
   pub(crate) units: Units,
 }
@@ -75,7 +78,8 @@ pub struct Rgb {
 iter_def!(Rgb);
 
 pub(crate) fn new_rgb_units(r: f64, g: f64, b: f64) -> Units {
-  let ul = [Unit::new_rgb(r), Unit::new_rgb(g), Unit::new_rgb(b), Unit::default()];
+  let ul =
+    [Unit::new_rgb(r), Unit::new_rgb(g), Unit::new_rgb(b), Unit::default()];
   Units { len: 3, list: ul, alpha: Alpha::default() }
 }
 
@@ -86,7 +90,9 @@ impl Rgb {
     self.units.list[2].value = t.2;
   }
 
-  pub(crate) fn from_units(u: Units) -> Self { Rgb { units: u } }
+  pub(crate) fn from_units(u: Units) -> Self {
+    Rgb { units: u }
+  }
 
   pub fn new(r: f64, g: f64, b: f64, a: Option<f64>) -> Rgb {
     let mut units = new_rgb_units(r, g, b);
@@ -104,7 +110,9 @@ impl Rgb {
     converters::rgb_to_hex(&self.into())
   }
 
-  pub fn red(&self) -> f64 { self.units[0] }
+  pub fn red(&self) -> f64 {
+    self.units[0]
+  }
   pub fn green(&self) -> f64 {
     self.units[1]
   }
@@ -113,7 +121,9 @@ impl Rgb {
   }
 
   #[deprecated(since = "0.7.0", note = "Please use `red` instead")]
-  pub fn get_red(&self) -> f64 { self.red() }
+  pub fn get_red(&self) -> f64 {
+    self.red()
+  }
   #[deprecated(since = "0.7.0", note = "Please use `green` instead")]
   pub fn get_green(&self) -> f64 {
     self.green()
@@ -123,9 +133,15 @@ impl Rgb {
     self.blue()
   }
 
-  pub fn set_red(&mut self, val: f64) { self.units.list[0].set(val); }
-  pub fn set_green(&mut self, val: f64) { self.units.list[1].set(val); }
-  pub fn set_blue(&mut self, val: f64) { self.units.list[2].set(val); }
+  pub fn set_red(&mut self, val: f64) {
+    self.units.list[0].set(val);
+  }
+  pub fn set_green(&mut self, val: f64) {
+    self.units.list[1].set(val);
+  }
+  pub fn set_blue(&mut self, val: f64) {
+    self.units.list[2].set(val);
+  }
 
   /// Returns a String that can be used in CSS.
   /// # Example

--- a/src/rgb/ratio.rs
+++ b/src/rgb/ratio.rs
@@ -24,6 +24,7 @@ use crate::units::{GetColorUnits, Units};
 /// ```
 ///
 #[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RgbRatio {
   pub(crate) units: Units,
 }
@@ -35,16 +36,28 @@ impl RgbRatio {
     RgbRatio { units }
   }
 
-  pub fn r(&self) -> f64 { self.units[0] }
-  pub fn g(&self) -> f64 { self.units[1] }
-  pub fn b(&self) -> f64 { self.units[2] }
-  pub fn a(&self) -> f64 { self.units.alpha.get_f64() }
+  pub fn r(&self) -> f64 {
+    self.units[0]
+  }
+  pub fn g(&self) -> f64 {
+    self.units[1]
+  }
+  pub fn b(&self) -> f64 {
+    self.units[2]
+  }
+  pub fn a(&self) -> f64 {
+    self.units.alpha.get_f64()
+  }
 
-  pub(crate) fn from_units(u: Units) -> Self { RgbRatio { units: u } }
+  pub(crate) fn from_units(u: Units) -> Self {
+    RgbRatio { units: u }
+  }
 }
 
 impl AsRef<RgbRatio> for RgbRatio {
-  fn as_ref(&self) -> &RgbRatio { self }
+  fn as_ref(&self) -> &RgbRatio {
+    self
+  }
 }
 
 

--- a/src/rgb/tests.rs
+++ b/src/rgb/tests.rs
@@ -1,5 +1,5 @@
-use crate::{ColorTransform, ColorTuple, ColorTupleA, ParseError, Rgb};
 use crate::common::f64_round;
+use crate::{ColorTransform, ColorTuple, ColorTupleA, ParseError, Rgb};
 
 fn round(n: f64) -> u32 {
   f64_round(n) as u32
@@ -89,4 +89,3 @@ fn rgb_from() {
 
   assert_eq!(rgb1, rgb2);
 }
-

--- a/src/rgb/transform.rs
+++ b/src/rgb/transform.rs
@@ -1,8 +1,8 @@
 use consts::RGB_UNIT_MAX;
 
-use crate::{ColorTransform, consts, SaturationInSpace};
+use crate::{ColorTransform, SaturationInSpace, consts};
 
-use super::{grayscale, Hsl, Rgb};
+use super::{Hsl, Rgb, grayscale};
 
 impl ColorTransform for Rgb {
   /// Lighten or darken color. amt is a percent with negative values - `-100..100`
@@ -67,7 +67,7 @@ impl ColorTransform for Rgb {
 
 #[cfg(test)]
 mod test {
-  use crate::{Rgb, ColorTransform};
+  use crate::{ColorTransform, Rgb};
 
   #[test]
   fn lighten_darken_test() {

--- a/src/units/alpha.rs
+++ b/src/units/alpha.rs
@@ -5,6 +5,7 @@ use crate::consts::RATIO_MAX;
 use crate::{ApproxEq, DEFAULT_APPROX_EQ_PRECISION};
 
 #[derive(Clone, PartialEq, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct Alpha {
   value: Option<Unit>,
 }

--- a/src/units/into.rs
+++ b/src/units/into.rs
@@ -1,4 +1,4 @@
-use crate::units::{Units};
+use crate::units::Units;
 
 
 impl Into<[f64; 3]> for &Units {
@@ -24,4 +24,3 @@ impl Into<[f64; 4]> for Units {
     [self[0], self[1], self[2], self[3]]
   }
 }
-

--- a/src/units/iter.rs
+++ b/src/units/iter.rs
@@ -28,7 +28,9 @@ impl ColorUnitsIter {
 impl core::iter::Iterator for ColorUnitsIter {
   type Item = f64;
   fn next(&mut self) -> Option<Self::Item> {
-    if self.ind == self.len { return None; }
+    if self.ind == self.len {
+      return None;
+    }
     let v = self.values[self.ind];
     self.ind += 1;
     Some(v)

--- a/src/units/mod.rs
+++ b/src/units/mod.rs
@@ -3,13 +3,13 @@ use core::ops::{Add, Index, Sub};
 pub(crate) use alpha::Alpha;
 pub(crate) use unit::Unit;
 
-use crate::{ApproxEq, DEFAULT_APPROX_EQ_PRECISION};
 use crate::common::approx::approx;
+use crate::{ApproxEq, DEFAULT_APPROX_EQ_PRECISION};
 
-mod unit;
 mod alpha;
 mod into;
 pub mod iter;
+mod unit;
 
 pub trait GetColorUnits {
   fn get_units(&self) -> &Units;
@@ -18,6 +18,7 @@ pub trait GetColorUnits {
 
 
 #[derive(Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Units {
   pub(crate) len: usize,
   pub(crate) list: [Unit; 4],
@@ -75,7 +76,9 @@ impl Units {
 
 
   pub(crate) fn new_ratios(values: &[f64]) -> Units {
-    if values.len() > 4 { panic!("length of units values is more than 4") }
+    if values.len() > 4 {
+      panic!("length of units values is more than 4")
+    }
     let mut ul: [Unit; 4] = Default::default();
     for (ind, v) in values.iter().enumerate() {
       ul[ind].set(*v);

--- a/src/units/unit.rs
+++ b/src/units/unit.rs
@@ -4,12 +4,14 @@ use core::ops::{Add, Sub};
 use crate::consts::{ALL_MIN, HUE_MAX, PERCENT_MAX, RATIO_MAX, RGB_UNIT_MAX};
 
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Unit {
   pub(crate) value: f64,
   kind: UnitType,
 }
 
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 enum UnitType {
   Rgb,
   Hue,
@@ -37,9 +39,7 @@ impl Default for Unit {
 
 impl fmt::Debug for Unit {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    f.debug_struct("ColorUnit")
-      .field("value", &self.value)
-      .finish()
+    f.debug_struct("ColorUnit").field("value", &self.value).finish()
   }
 }
 

--- a/tests/tst.rs
+++ b/tests/tst.rs
@@ -1,9 +1,9 @@
 #[allow(unused_imports)]
-use colorsys::{prelude::*, Hsl, Rgb};
+use colorsys::{Hsl, Rgb, prelude::*};
 
 #[test]
 fn for_docs() {
-  use colorsys::{Rgb, Hsl};
+  use colorsys::{Hsl, Rgb};
 
   let rbga_tuple = (57.3, 12.7, 53.0, 0.33);
   let rgba = Rgb::from(&rbga_tuple);
@@ -26,25 +26,17 @@ fn for_docs() {
 
   let rgb1 = Rgb::from_hex_str("37ea4c").unwrap();
 
-  let rgb2 = Rgb::from(
-    Into::<[f32; 4]>::into(Rgb::from(
-      Into::<[u16; 3]>::into(
-        Rgb::from(
-          Into::<(i32, i32, i32)>::into(
-            Rgb::from(
-              Into::<[i64; 3]>::into(&rgb1)
-            )
-          )
-        )
-      )
-    ))
-  );
+  let rgb2 = Rgb::from(Into::<[f32; 4]>::into(Rgb::from(
+    Into::<[u16; 3]>::into(Rgb::from(Into::<(i32, i32, i32)>::into(
+      Rgb::from(Into::<[i64; 3]>::into(&rgb1)),
+    ))),
+  )));
 
   assert_eq!(rgb1, rgb2);
   //
   // Ratio
   //
-  use colorsys::{RgbRatio, ApproxEq};
+  use colorsys::{ApproxEq, RgbRatio};
   let blue = Rgb::from([34, 111, 235]);
 
   let ratio: [f32; 4] = blue.as_ratio().into();


### PR DESCRIPTION
As per title, this PR adds optional support for [serde](https://serde.rs/) derive macros for all struct and enums in the crate.

This is handled by the new optional feature flag `"serde"`.

Closes issue #8 